### PR TITLE
Implement locking to prevent import errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "jenkins-plugin", '~> 0.2.0'
 #gem "vagrant", '~> 1.0.1'
 gem 'vagrant', :git => 'git://github.com/rtyler/vagrant', :ref => '8a5b1ad'
 gem 'jruby-openssl'
+gem 'lockfile'
 
 group :development do
   gem 'jpi', '~> 0.3.3'


### PR DESCRIPTION
Hi, this is my first ever bit of ruby code, so go easy on me :)

I described in an issue against Vagrant: mitchellh/vagrant#1075 basically it's easy with the Vagrant plugin for Jenkins to import two VMs at once, which VBoxManage seemingly can't handle. Seeing as how in that issue the Vagrant maintainer says he'll get around to fixing this at some point, I've implemented a workaround in the vagrant-plugin here.

Not sure this is the best way to implement locking in JRuby, but it seems to work.
