### PR TITLE
Fix undefined local variable or method `built`

### DIFF
--- a/models/vagrant_builder.rb
+++ b/models/vagrant_builder.rb
@@ -117,7 +117,7 @@ module Vagrant
     def perform(build, launcher, listener)
       @vagrant = build.env[:vagrant]
       if @vagrant.nil?
-        built.halt "OH CRAP! I don't seem to have a Vagrant instance"
+        build.halt "OH CRAP! I don't seem to have a Vagrant instance"
       end
 
       if @vagrant.multivm?


### PR DESCRIPTION
Fix syntax error which was causing plugin to return 'ERROR: undefined local variable or method ' if there was no Vagrant instance.
