### PR TITLE
Add support for VirtualBox 4.2 without munging the JPI version, and using vagrant 1.0.5

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,9 @@
 # Vagrant plugin Changelog
 
+### 0.1.5
+
+* Added support for VirtualBox 4.2, utilizing vagrant 1.0.6 from https://github.com/mitchellh/vagrant-plugin 
+
 ### 0.1.4
 
 * Fix overriding of the Jenkins SIGINT/TERM handler  ([GH-14](https://github.com/rtyler/vagrant-plugin/issues/14))

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source :gemcutter
 gem "jenkins-plugin-runtime"
 gem "jenkins-plugin", '~> 0.2.0'
 #gem "vagrant", '~> 1.0.1'
-gem 'vagrant', :git => 'git://github.com/rtyler/vagrant', :ref => '8a5b1ad'
+gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant', :ref => '10a051a64b'
 gem 'jruby-openssl'
 gem 'lockfile'
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source :gemcutter
 
 gem "jenkins-plugin-runtime"
 gem "jenkins-plugin", '~> 0.2.0'
-#gem "vagrant", '~> 1.0.1'
-gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant', :ref => '10a051a64b'
+gem "vagrant", '~> 1.0.5'
+#gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant', '~/ 1.0.5'
 gem 'jruby-openssl'
 gem 'lockfile'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GIT
-  remote: git://github.com/rtyler/vagrant
-  revision: 8a5b1ad0d1efa1ab5c1e2659f1e97e77b1fbacbd
-  ref: 8a5b1ad
+  remote: https://github.com/mitchellh/vagrant
+  revision: 10a051a64bdfff47e1ed372616f4f288638d8ca8
+  ref: 10a051a64b
   specs:
-    vagrant (1.0.2.dev)
+    vagrant (1.1.0.dev)
       archive-tar-minitar (= 0.5.2)
       childprocess (~> 0.3.1)
       erubis (~> 2.7.0)
       i18n (~> 0.6.0)
-      json (~> 1.5.1)
+      json (~> 1.6.6)
       log4r (~> 1.1.9)
       net-scp (~> 1.0.4)
       net-ssh (~> 2.2.2)
@@ -18,43 +18,43 @@ GEM
   specs:
     archive-tar-minitar (0.5.2)
     bouncy-castle-java (1.5.0146.1)
-    childprocess (0.3.1)
-      ffi (~> 1.0.6)
+    childprocess (0.3.6)
+      ffi (~> 1.0, >= 1.0.6)
     diff-lcs (1.1.3)
     erubis (2.7.0)
-    ffi (1.0.11-java)
-    i18n (0.6.0)
+    ffi (1.3.1-java)
+    i18n (0.6.1)
     jenkins-plugin (0.2.0)
-    jenkins-plugin-runtime (0.1.26)
+    jenkins-plugin-runtime (0.2.3)
       json
       slop (~> 3.0.2)
-    jenkins-war (1.447)
-    jpi (0.3.3)
-      bundler (~> 1.1.rc2)
-      jenkins-plugin-runtime (~> 0.1.13)
-      jenkins-war (>= 1.427)
+    jenkins-war (1.475)
+    jpi (0.3.8)
+      bundler
+      jenkins-plugin-runtime (~> 0.2.3)
+      jenkins-war (> 1.427)
       rubyzip
       thor
-    jruby-openssl (0.7.4)
-      bouncy-castle-java
-    json (1.5.4)
-    json (1.5.4-java)
+    jruby-openssl (0.8.2)
+      bouncy-castle-java (>= 1.5.0146.1)
+    json (1.6.7-java)
+    lockfile (2.1.0)
     log4r (1.1.10)
     net-scp (1.0.4)
       net-ssh (>= 1.99.1)
     net-ssh (2.2.2)
-    rake (0.9.2.2)
-    rspec (2.8.0)
-      rspec-core (~> 2.8.0)
-      rspec-expectations (~> 2.8.0)
-      rspec-mocks (~> 2.8.0)
-    rspec-core (2.8.0)
-    rspec-expectations (2.8.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.8.0)
-    rubyzip (0.9.6.1)
+    rake (10.0.3)
+    rspec (2.12.0)
+      rspec-core (~> 2.12.0)
+      rspec-expectations (~> 2.12.0)
+      rspec-mocks (~> 2.12.0)
+    rspec-core (2.12.2)
+    rspec-expectations (2.12.1)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.12.1)
+    rubyzip (0.9.9)
     slop (3.0.4)
-    thor (0.14.6)
+    thor (0.16.0)
 
 PLATFORMS
   java
@@ -64,6 +64,7 @@ DEPENDENCIES
   jenkins-plugin-runtime
   jpi (~> 0.3.3)
   jruby-openssl
+  lockfile
   rake
   rspec
   vagrant!

--- a/vagrant-plugin.pluginspec
+++ b/vagrant-plugin.pluginspec
@@ -2,7 +2,7 @@
 Jenkins::Plugin::Specification.new do |plugin|
   plugin.name = 'vagrant'
   plugin.display_name = 'Vagrant Plugin'
-  plugin.version = '0.1.4'
+  plugin.version = '0.1.5'
   plugin.description = 'The Vagrant plugin allows you to bring up a Vagrant VM for the duration of your job'
 
   plugin.url = 'https://wiki.jenkins-ci.org/display/JENKINS/Vagrant+Plugin'


### PR DESCRIPTION
Minimal changes made to add support for VB 4.2 (mainly, using vagrant 1.0.5) I tried to leave as much in tact as possible, and I think I succeed!  My apologies for switching from git:// to https://, I am unable to use git/ssh outside of my network.
