### PR TITLE
Update jenkins-plugin-runtime and jruby-openssl to fix #26

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source :gemcutter
 
-gem "jenkins-plugin-runtime"
+gem "jenkins-plugin-runtime", "~> 0.2.3"
 gem "jenkins-plugin", '~> 0.2.0'
 gem "vagrant", '~> 1.0.5'
 #gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant', '~/ 1.0.5'
-gem 'jruby-openssl'
+gem 'jruby-openssl', '~> 0.8.4'
 gem 'lockfile'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,14 @@
-GIT
-  remote: https://github.com/mitchellh/vagrant
-  revision: 10a051a64bdfff47e1ed372616f4f288638d8ca8
-  ref: 10a051a64b
-  specs:
-    vagrant (1.1.0.dev)
-      archive-tar-minitar (= 0.5.2)
-      childprocess (~> 0.3.1)
-      erubis (~> 2.7.0)
-      i18n (~> 0.6.0)
-      json (~> 1.6.6)
-      log4r (~> 1.1.9)
-      net-scp (~> 1.0.4)
-      net-ssh (~> 2.2.2)
-
 GEM
   remote: http://rubygems.org/
   specs:
     archive-tar-minitar (0.5.2)
-    bouncy-castle-java (1.5.0146.1)
-    childprocess (0.3.6)
-      ffi (~> 1.0, >= 1.0.6)
+    bouncy-castle-java (1.5.0147)
+    childprocess (0.3.9)
+      ffi (~> 1.0, >= 1.0.11)
     diff-lcs (1.1.3)
     erubis (2.7.0)
-    ffi (1.3.1-java)
-    i18n (0.6.1)
+    ffi (1.4.0-java)
+    i18n (0.6.4)
     jenkins-plugin (0.2.0)
     jenkins-plugin-runtime (0.2.3)
       json
@@ -35,9 +20,9 @@ GEM
       jenkins-war (> 1.427)
       rubyzip
       thor
-    jruby-openssl (0.8.2)
-      bouncy-castle-java (>= 1.5.0146.1)
-    json (1.6.7-java)
+    jruby-openssl (0.8.5)
+      bouncy-castle-java (>= 1.5.0147)
+    json (1.7.7-java)
     lockfile (2.1.0)
     log4r (1.1.10)
     net-scp (1.0.4)
@@ -55,16 +40,25 @@ GEM
     rubyzip (0.9.9)
     slop (3.0.4)
     thor (0.16.0)
+    vagrant (1.0.7)
+      archive-tar-minitar (= 0.5.2)
+      childprocess (~> 0.3.1)
+      erubis (~> 2.7.0)
+      i18n (~> 0.6.0)
+      json (>= 1.5.1, < 1.8.0)
+      log4r (~> 1.1.9)
+      net-scp (~> 1.0.4)
+      net-ssh (~> 2.2.2)
 
 PLATFORMS
   java
 
 DEPENDENCIES
   jenkins-plugin (~> 0.2.0)
-  jenkins-plugin-runtime
+  jenkins-plugin-runtime (~> 0.2.3)
   jpi (~> 0.3.3)
-  jruby-openssl
+  jruby-openssl (~> 0.8.4)
   lockfile
   rake
   rspec
-  vagrant!
+  vagrant (~> 1.0.5)

--- a/models/vagrant_wrapper.rb
+++ b/models/vagrant_wrapper.rb
@@ -8,7 +8,7 @@ module Vagrant
   class ConsoleInterface
     attr_accessor :listener, :resource
 
-    def initializer(resource)
+    def initialize(resource)
       @listener = nil
       @resource = resource
     end

--- a/vagrant-plugin.pluginspec
+++ b/vagrant-plugin.pluginspec
@@ -2,7 +2,7 @@
 Jenkins::Plugin::Specification.new do |plugin|
   plugin.name = 'vagrant'
   plugin.display_name = 'Vagrant Plugin'
-  plugin.version = '0.1.5'
+  plugin.version = '0.1.5-SNAPSHOT'
   plugin.description = 'The Vagrant plugin allows you to bring up a Vagrant VM for the duration of your job'
 
   plugin.url = 'https://wiki.jenkins-ci.org/display/JENKINS/Vagrant+Plugin'


### PR DESCRIPTION
In order to fix #26 the Jenkins team must first accept the pull requests https://github.com/jenkinsci/jenkins.rb/pull/70 and https://github.com/stapler/stapler/pull/14.

I'm not sure if there's a cleaner way to handle this but after upgrading to jenkins-plugin-runtime 0.2.3 with vagrant-plugin I had to hand edit my config.xmls because they were referencing Jenkins::Plugin::Proxies::Builder instead of Jenkins::Tasks::BuilderProxy.

For users that are interested, I have built a custom version of the ruby-runtime plugin for Jenkins.  You can download [ruby-runtime.hpi](https://dl.dropbox.com/u/35989164/ruby-runtime.hpi) and [vagrant-plugin.hpi](https://dl.dropbox.com/u/35989164/vagrant.hpi) and install both of those plugins into Jenkins 1.505+.
